### PR TITLE
Add name and parent to Corns

### DIFF
--- a/Source/FlecsTest/FlecsSubsystem.cpp
+++ b/Source/FlecsTest/FlecsSubsystem.cpp
@@ -73,7 +73,9 @@ FFlecsEntityHandle UFlecsSubsystem::SpawnCornEntity(FVector location, FRotator r
 	auto entity = GetEcsWorld()->entity()
 	.set<FlecsIsmRef>({CornRenderer})
 	.set<FlecsISMIndex>({IsmID})
-	.set<FlecsCorn>({0});
+	.set<FlecsCorn>({0})
+	.child_of<Corns>()
+	.set_name(StringCast<ANSICHAR>(*FString::Printf(TEXT("Corn%d"), IsmID)).Get());
 	return FFlecsEntityHandle{int(entity.id())};
 }
 

--- a/Source/FlecsTest/FlecsSubsystem.h
+++ b/Source/FlecsTest/FlecsSubsystem.h
@@ -21,6 +21,7 @@ struct FlecsCorn
 {
 	float Growth;
 };
+struct Corns {};
 
 USTRUCT(BlueprintType)
 struct FFlecsEntityHandle


### PR DESCRIPTION
Following the example of the official Tower Defense demo https://github.com/SanderMertens/tower_defense/blob/master/src/main.cpp#L394 and for better visualization in the Explorer, parent Corn entities and set readable instance names.

![CornIdentification](https://user-images.githubusercontent.com/248383/229365815-2db90ed7-e5e1-4df6-b4c6-1832ab7a9e88.jpg)
