### PR TITLE
Incorrect world destruction fix for FlecsSubsystem.cpp

### DIFF
--- a/Source/FlecsTest/FlecsSubsystem.cpp
+++ b/Source/FlecsTest/FlecsSubsystem.cpp
@@ -62,7 +62,12 @@ void UFlecsSubsystem::InitFlecs(UStaticMesh* InMesh)
 void UFlecsSubsystem::Deinitialize()
 {
 	FTSTicker::GetCoreTicker().RemoveTicker(OnTickHandle);
-	if(!ECSWorld) delete(ECSWorld);
+	
+	if (ECSWorld)
+	{
+		delete ECSWorld;
+	}
+	
 	UE_LOG(LogTemp, Warning, TEXT("UUnrealFlecsSubsystem has shut down!"));
 	Super::Deinitialize();
 }

--- a/Source/FlecsTest/FlecsSubsystem.cpp
+++ b/Source/FlecsTest/FlecsSubsystem.cpp
@@ -66,6 +66,7 @@ void UFlecsSubsystem::Deinitialize()
 	if (ECSWorld)
 	{
 		delete ECSWorld;
+		ECSWorld = nullptr;
 	}
 	
 	UE_LOG(LogTemp, Warning, TEXT("UUnrealFlecsSubsystem has shut down!"));


### PR DESCRIPTION
ECSWorld was never destroyed, which lead to Rest API module getting stuck and potentially other side-effects.

WTR:
Without rebuilding / restarting editor:
- Start the game;
- Stop the game;
- Start the game;

ER:
- Explorer finds the world correctly;

AR:
- Rest API is unavailable, because the same port is already occupied by undisposed world.